### PR TITLE
Add procps dependency for -with-trace option

### DIFF
--- a/payload-gen-seq-experiment/Dockerfile
+++ b/payload-gen-seq-experiment/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.7.5-slim-buster
 
 LABEL org.opencontainers.image.source https://github.com/icgc-argo/data-processing-utility-tools
 
+RUN apt-get update && apt-get install -y procps
+
 ENV PATH="/tools:${PATH}"
 
 COPY *.py /tools/


### PR DESCRIPTION
To resolve same issue as https://github.com/icgc-argo/data-processing-utility-tools/pull/100/commits/9e00603b93aa33ed76f852ff40881281598fdb2b